### PR TITLE
Card images

### DIFF
--- a/components/ResultCards.vue
+++ b/components/ResultCards.vue
@@ -9,7 +9,7 @@
           class=" rounded-lg bg-gray-200 tablet:shadow-md desktop:shadow-md flex flex-col overflow-hidden"
         >
           <div class="relative overflow-hidden bg-cover bg-no-repeat">
-            <img class="rounded-t-lg" src="~/assets/images/mushy.jpg" alt="this is a pic of a mushy" />
+            <nuxt-img class="rounded-t-lg" provider="cloudinary" :src="`ar_3:4,c_fill,h_1024,w_768/${mushroom.photos[0]}`" alt="Mushroom Image"></nuxt-img>
             <!-- Adds a warning label for toxic mushrooms -->
             <span
               v-if="mushroom.edibility.includes('toxic')"

--- a/data/sampledata.js
+++ b/data/sampledata.js
@@ -40,7 +40,7 @@ export default [
     "time_of_year": "Late spring to autumn (October to April in the Southern Hemisphere)",
     "native_or_introduced": "introduced",
     "genus": "coprinus",
-    "photos": []
+    "photos": ["MushroomCards/ShaggyManeCard_egc21k.jpg"]
   },
 
   {
@@ -84,7 +84,7 @@ export default [
     "time_of_year": "Late summer to autumn (March to June in the Southern Hemisphere)",
     "native_or_introduced": "introduced",
     "genus": "Amanita",
-    "photos": []
+    "photos": ["MushroomCards/AmanitaMuscariaCard_gy8lsy.jpg"]
   },
 
   {
@@ -128,7 +128,7 @@ export default [
     "time_of_year": "Autumn (March to May in the Southern Hemisphere)",
     "native_or_introduced": "introduced",
     "genus": "Gymnopilus",
-    "photos": []
+    "photos": ["MushroomCards/LaughingGymCard_yo4quk.jpg"]
   },
 
   {
@@ -172,7 +172,7 @@ export default [
     "time_of_year": "Late summer to autumn (February to May in the Southern Hemisphere)",
     "native_or_introduced": "native",
     "genus": "Psilocybe",
-    "photos": []
+    "photos": ["MushroomCards/PsilocybeWeraroaCard_ipwjeo.jpg"]
   },
 
   {
@@ -216,7 +216,7 @@ export default [
     "time_of_year": "(April to June)",
     "native_or_introduced": "native",
     "genus": "Cortinarius",
-    "photos": []
+    "photos": ["MushroomCards/PurplePouchCard_mtfrc3.jpg"]
   },
 
   {
@@ -260,7 +260,7 @@ export default [
     "time_of_year": "(February to June)",
     "native_or_introduced": "introduced",
     "genus": "Cortinarius",
-    "photos": []
+    "photos": ["MushroomCards/ShaggyParasolCard_e61grf.jpg"]
   },
 
   {
@@ -304,7 +304,7 @@ export default [
     "time_of_year": "late summer into autumn (February to June)",
     "native_or_introduced": "Introduced",
     "genus": "Leccinum",
-    "photos": []
+    "photos": ["MushroomCards/BirchBoleteCard_jkkl6o.jpg"]
   },
 
   {
@@ -348,7 +348,7 @@ export default [
     "time_of_year": "Autumn (March to May)",
     "native_or_introduced": "Introduced",
     "genus": "Lycoperdon",
-    "photos": []
+    "photos": ["MushroomCards/CommonPuffballCard_hporke.jpg"]
   },
 
   {
@@ -392,7 +392,7 @@ export default [
     "time_of_year": "Spring, autumn (April to July)",
     "native_or_introduced": "Introduced",
     "genus": "Pleurotus",
-    "photos": []
+    "photos": ["MushroomCards/OysterCard_cogvbc.jpg"]
   },
 
   {
@@ -436,7 +436,7 @@ export default [
     "time_of_year": "Autumn, winter (March to July)",
     "native_or_introduced": "Native",
     "genus": "Hericium",
-    "photos": []
+    "photos": ["MushroomCards/LionsManeCard_vhbdjh.jpg"]
   },
 
   {
@@ -480,7 +480,7 @@ export default [
     "time_of_year": "Autumn (March to May)",
     "native_or_introduced": "Introduced",
     "genus": "Agaricus",
-    "photos": []
+    "photos": ["MushroomCards/MeadowMushroomCard_y7dlhy.jpg"]
   },
 
   {
@@ -524,7 +524,7 @@ export default [
     "time_of_year": "Summer, autumn (November to June)",
     "native_or_introduced": "Native",
     "genus": "Cyclocybe",
-    "photos": []
+    "photos": ["MushroomCards/TawakaCard_g6ndwo.jpg"]
   },
   {
     "id":13,
@@ -567,7 +567,7 @@ export default [
     "time_of_year": "Autumn, winter (February - August)",
     "native_or_introduced": "Native",
     "genus": "Macrolepiota",
-    "photos": []
+    "photos": ["MushroomCards/GracefulParasolCard_bkmw4v.jpg"]
   },
   {
     "id":14,
@@ -610,7 +610,7 @@ export default [
     "time_of_year": "Autumn, winter (February - August)",
     "native_or_introduced": "introduced",
     "genus": "Amanita",
-    "photos": []
+    "photos": ["MushroomCards/DeathCapCard_ueb21p.jpg"]
   },
   {
     "id":15,
@@ -653,7 +653,7 @@ export default [
     "time_of_year": "Autumn, winter (March - August)",
     "native_or_introduced": "native",
     "genus": "Armillaria",
-    "photos": []
+    "photos": ["MushroomCards/AustralHoneyCard_wys1f8.jpg"]
   },
 
 ]

--- a/data/sampledata.js
+++ b/data/sampledata.js
@@ -4,14 +4,18 @@ export default [
     "tags":["edible"],
     "latin_names": "Coprinus comatus",
     "common_names": "Shaggy Mane",
-    "description": "The Shaggy Mane is a distinctive mushroom with a white, cylindrical cap that is covered in shaggy scales. When young, the cap is elongated and bullet-shaped, but as it matures, it opens up, and the edges become wavy. The gills are initially white, then turn black and eventually dissolve into an inky liquid, a process known as deliquescence. The stipe is white and hollow.",
-    "lookalikes": "The mushroom can sometimes be confused with the magpie fungus which is poisonous. In America, the 'vomiter' mushroom Chlorophyllum molybdites is responsible for most cases of mushroom poisoning due to its similarity with shaggy mane and other edible mushrooms.[8] Coprinopsis atramentaria (the common Ink Cap) is similar, and contains coprine and can induce coprine poisoning, particularly when consumed with alcohol.[5] Podaxis pistillaris is also similar.",
+    "description": "The Shaggy Mane is a distinctive mushroom with a white, cylindrical cap that is covered in shaggy scales. When young, the cap is elongated and bullet-shaped, \
+    but as it matures, it opens up, and the edges become wavy. The gills are initially white, then turn black and eventually dissolve into an inky liquid, a process known as \
+    deliquescence. The stipe is white and hollow.",
+    "lookalikes": "The mushroom can sometimes be confused with the magpie fungus which is poisonous (Aus). Coprinopsis atramentaria (the common Ink Cap) is similar, and contains \
+    coprine and can induce coprine poisoning, particularly when consumed with alcohol (NZ). Podaxis pistillaris is also similar (Aus).",
     "links": {
       "iNaturalist": "https://www.inaturalist.org/taxa/47392-Coprinus-comatus",
       "wikipedia": "https://en.wikipedia.org/wiki/Coprinus_comatus"
     },
     "nz_books": "A Field Guide to the Fungi of New Zealand by E.J.H. Corner and P.D. Orton",
-    "edibility": "Edible when young and fresh. However, it is not recommended to consume alcohol within a few hours before or after eating this mushroom due to potential adverse reactions.",
+    "edibility": "Edible when young and fresh. However, it is not recommended to consume alcohol within a few hours before or after eating this mushroom due to potential adverse \
+    reactions.",
     "stipe_features": {
       "diameter_min": 1,
       "diameter_max": 2.5,
@@ -48,8 +52,10 @@ export default [
     "tags":["poisonous", "psychoactive"],
     "latin_names": "Amanita muscaria",
     "common_names": "Fly Agaric, Fly Amanita",
-    "description": "Amanita muscaria is a striking and iconic mushroom with a bright red to orange cap covered in white to yellow warts. The cap is usually convex, but it flattens with age. The gills are white, and the stipe is white with a distinctive ring.",
-    "lookalikes": "Amanita muscaria has several lookalike species, some of which are toxic: Caesar’s Mushroom / Amanita Caesarea, Vermilion Grisette / Amanita Xanthocephala",
+    "description": "Amanita muscaria is a striking and iconic mushroom with a bright red to orange cap covered in white to yellow warts. The cap is usually convex, but it flattens \
+    with age. The gills are white, and the stipe is white with a distinctive ring.",
+    "lookalikes": "No known lookalikes in New Zealand. In Australia, the introduced fly agaric may be confused with the native vermilion grisette (Amanita xanthocephala), which \
+    grows in association with eucalypts. The species generally lacks the white warts of A. muscaria and bears no ring.",
     "links": {
       "iNaturalist": "https://www.inaturalist.org/taxa/48715-Amanita-muscaria",
       "wikipedia": "https://en.wikipedia.org/wiki/Amanita_muscaria"
@@ -92,8 +98,10 @@ export default [
     "tags":["poisonous"],
     "latin_names": "Gymnopilus junonius",
     "common_names": "Laughing Gym, Spectacular Rustgill",
-    "description": "Gymnopilus junonius is a medium-sized mushroom with a distinctively rusty-brown to orange cap. The cap is convex to broadly convex when young, and it often develops a central depression as it matures. The gills are orange-brown, and the stipe is fibrous and often has a ring.",
-    "lookalikes": "Gymnopilus Ventricosus, Yellow Gymnopilus / Gymnopilus Luteus, Gymnopilus Subspectabilis",
+    "description": "Gymnopilus junonius is a medium-sized mushroom with a distinctively rusty-brown to orange cap. The cap is convex to broadly convex when young, and it often \
+    develops a central depression as it matures. The gills are orange-brown, and the stipe is fibrous and often has a ring.",
+    "lookalikes": "This mushroom is often mistaken for Gymnopilus ventricosus, which also contains no psilocybin and G. luteus and G. subspectabilis, which do. It also resembles \
+    Armillaria mellea and Omphalotus olivascens.",
     "links": {
       "iNaturalist": "https://inaturalist.nz/taxa/1155105-Gymnopilus-junonius",
       "wikipedia": "https://en.wikipedia.org/wiki/Gymnopilus_junonius"
@@ -136,8 +144,12 @@ export default [
     "tags":["psychoactive"],
     "latin_names": "Psilocybe weraroa, Weraroa Novae-Zelandiae",
     "common_names": "Weraroa Magic Mushroom",
-    "description": "Psilocybe weraroa is a small mushroom with a conical to bell-shaped cap. The cap is typically brown to dark brown, and the gills are pale brown when young, becoming dark purple-brown with age. The stipe is slender and often has a blueish coloration near the base.",
-    "lookalikes": "Psilocybe weraroa has several lookalike species, but its characteristic blueish coloration on the stipe sets it apart. Blue Pouch Fungus / Clavogaster Virescens",
+    "description": "Psilocybe weraroa is a small mushroom with a conical to bell-shaped cap. The cap is typically brown to dark brown, and the gills are pale brown when young, \
+    becoming dark purple-brown with age. The stipe is slender and often has a blueish coloration near the base.",
+    "lookalikes": "Clavogaster virescens, a close lookalike often mistaken for P. weraroa by foragers. Clavogaster virescens is similar in appearance and habitat, but the gleba \
+    form a reddish brown chambered mass enclosed inside a sack-like structure within the peridium. The stem is stout, smooth and slippery rather than fibrous, off-white to yellow, \
+    enlarged at the top where it often smoothly transitions into the pouch, and tapering towards a yellower base. The fungus does not have a bluing reaction; it is naturally blue \
+    to greenish blue, and has no psychoactive properties.",
     "links": {
       "iNaturalist": "https://inaturalist.nz/taxa/126163-Psilocybe-weraroa",
       "wikipedia": "https://en.wikipedia.org/wiki/Psilocybe_weraroa"
@@ -180,8 +192,11 @@ export default [
     "tags":["poisonous"],
     "latin_names": "Cortinarius Porphyroideus",
     "common_names": "Purple Pouch Fungus, Purple Cortinarius",
-    "description": "Cortinarius porphyroideus, commonly known as purple pouch fungus, is a secotioid species of fungus endemic to New Zealand. It was one of six species that appeared as part of a series depicting native New Zealand fungi on stamps, released in 2002.",
-    "lookalikes": "Although there are many Cortinarius species with some degree of violet colour, C. violaceus and its close relatives are easily distinguished by their much darker purple colour.  Cortinarius iodes of the southeastern United States has a slimy purple cap and paler violet stipe.[23] The other species in the section Cortinarius are dark purple and superficially similar, but can be differentiated based on host and geography as they do not occur in the same locations as C. violaceus.",
+    "description": "Cortinarius porphyroideus, commonly known as purple pouch fungus, is a secotioid species of fungus endemic to New Zealand. It was one of six species that \
+    appeared as part of a series depicting native New Zealand fungi on stamps, released in 2002.",
+    "lookalikes": "Although there are many Cortinarius species with some degree of violet colour, C. violaceus and its close relatives are easily distinguished by their much \
+    darker purple colour.  Cortinarius iodes of the southeastern United States has a slimy purple cap and paler violet stipe. The other species in the section Cortinarius are \
+    dark purple and superficially similar, but can be differentiated based on host and geography as they do not occur in the same locations as C. violaceus.",
     "links": {
       "iNaturalist": "https://inaturalist.nz/taxa/127053-Cortinarius-porphyroideus",
       "wikipedia": "https://en.wikipedia.org/wiki/Cortinarius_porphyroideus"
@@ -224,8 +239,12 @@ export default [
     "tags":["poisonous"],
     "latin_names": "Chlorophyllum Rhacodes",
     "common_names": "Shaggy Parasol",
-    "description": "The shaggy parasol is a large and conspicuous agaric, with thick brown scales and protuberances on its fleshy white cap. The gills and sport print are both white in colour. Its stipe is slender, but bulbous at the base, is coloured uniformly and bears no patterns. It is fleshy, and a reddish, or maroon discoloration occurs and a pungent odour is evolved when it is cut. The egg-shaped caps become wider and flatter as they mature.",
-    "lookalikes": "Chlorophyllum molybdites, Macrolepiota procera",
+    "description": "The shaggy parasol is a large and conspicuous agaric, with thick brown scales and protuberances on its fleshy white cap. The gills and sport print are both \
+    white in colour. Its stipe is slender, but bulbous at the base, is coloured uniformly and bears no patterns. It is fleshy, and a reddish, or maroon discoloration occurs and \
+    a pungent odour is evolved when it is cut. The egg-shaped caps become wider and flatter as they mature.",
+    "lookalikes": "The shaggy parasol is similar in appearance to the similarly edible parasol mushroom, Macrolepiota procera. The latter grows considerably larger however, and \
+    is more likely to be found in the open than C. rhacodes which prefers more shade and dislikes open pastures and fields. Another distinguishing feature is that C. rhacodes lacks \
+    the brown bands that are on the stem of M. procera.",
     "links": {
       "iNaturalist": "https://inaturalist.nz/taxa/56535-Chlorophyllum-rhacodes",
       "wikipedia": "https://en.wikipedia.org/wiki/Shaggy_parasol"
@@ -269,13 +288,16 @@ export default [
     "latin_names": "Leccinum scabrum",
     "common_names": "Birch Bolete",
     "description": "The cap is hemispherical, and later becomes flatter. The skin of the cap is tan or brownish, usually with a lighter edge, it is smooth, bald, and dry to viscid",
-    "lookalikes": "Several different species of Leccinum mushrooms are found in mycorrhiza with birches, and can be confused by amateurs and mycologists alike. L. variicolor has a bluish stipe. L. oxydabile has firmer, pinkish flesh and a different pileus skin structure. L. melaneum is darker in color and has yellowish hues under the skin of the pileus and stipe. L. holopus is paler and whitish in all parts.",
+    "lookalikes": "Several different species of Leccinum mushrooms are found in mycorrhiza with birches, and can be confused by amateurs and mycologists alike. L. variicolor has \
+    a bluish stipe. L. oxydabile has firmer, pinkish flesh and a different pileus skin structure. L. melaneum is darker in color and has yellowish hues under the skin of the pileus \
+    and stipe. L. holopus is paler and whitish in all parts.",
     "links": {
       "iNaturalist": "https://inaturalist.nz/taxa/63232-Leccinum-scabrum",
       "wikipedia": "https://en.wikipedia.org/wiki/Leccinum_scabrum"
     },
     "nz_books": "A Field Guide to the Native Edible Plants of New Zealand",
-    "edibility": "The birch bolete is edible but considered not to be worthwhile by some guides. A few reports in North America suggest that Leccinums (birch boletes) should only be consumed with much caution.",
+    "edibility": "The birch bolete is edible but considered not to be worthwhile by some guides. A few reports in North America suggest that Leccinums (birch boletes) should \
+    only be consumed with much caution.",
     "stipe_features": {
       "diameter_min": 1,
       "diameter_max": 3.5,
@@ -312,8 +334,10 @@ export default [
     "tags":["edible"],
     "latin_names": "Lycoperdon perlatum",
     "common_names": "Common Puffball",
-    "description": "Medium-sized puffball mushroom with a round body and wide stalk and spiny bumps that can be rubbed off, white when immature but brown when mature and bursts open with a hole at the top",
-    "lookalikes": "Amanita mushrooms are similar when immature but toxic, cutting open a puffball should show smooth flesh while amanita mushrooms have gills inside, other puffball species can look similar",
+    "description": "Medium-sized puffball mushroom with a round body and wide stalk and spiny bumps that can be rubbed off, white when immature but brown when mature and bursts \
+    open with a hole at the top",
+    "lookalikes": "Amanita mushrooms are similar when immature but toxic, cutting open a puffball should show smooth flesh while amanita mushrooms have gills inside, other \
+    puffball species can look similar",
     "links": {
       "iNaturalist": "https://www.inaturalist.org/taxa/118132-Bovista-plumbea",
       "wikipedia": "https://en.wikipedia.org/wiki/Bovista_plumbea"
@@ -445,7 +469,8 @@ export default [
     "latin_names": "Agaricus campestris",
     "common_names": "Meadow mushroom",
     "description": "A white cap which may have scales, with pink to brown gills, stipe is white with a single thin ring",
-    "lookalikes": "Agaricus xanthodermus is poisonous and bruises yellow instead of reddish brown in edible meadow mushrooms, Agaricus genus has multiple similar-looking toxic and deadly related mushrooms not currently observed in New Zealand yet, but caution is advised, lookalikes may have a strong smell or slightly different shape or features",
+    "lookalikes": "Agaricus xanthodermus is poisonous and bruises yellow instead of reddish brown in edible meadow mushrooms, Agaricus genus has multiple similar-looking toxic \
+    and deadly related mushrooms not currently observed in New Zealand yet, but caution is advised, lookalikes may have a strong smell or slightly different shape or features",
     "links": {
       "iNaturalist": "https://inaturalist.nz/taxa/143563-Agaricus-campestris",
       "wikipedia": "https://en.wikipedia.org/wiki/Agaricus_campestris"
@@ -488,8 +513,9 @@ export default [
     "tags":["edible"],
     "latin_names": "Cyclocybe parasitica",
     "common_names": "Tawaka, poplar mushroom",
-    "description": "Brown cap, white stem, growing on trees, veil is pressing against the gills and turns into a prominent ring often striated with dark brown spore print upon the stem expansion",
-    "lookalikes": "",
+    "description": "Brown cap, white stem, growing on trees, veil is pressing against the gills and turns into a prominent ring often striated with dark brown spore print upon \
+    the stem expansion",
+    "lookalikes": "No known lookalikes",
     "links": {
       "iNaturalist": "https://inaturalist.nz/taxa/815897-Cyclocybe-parasitica",
       "wikipedia": "https://en.wikipedia.org/wiki/Cyclocybe_parasitica"
@@ -531,8 +557,15 @@ export default [
     "tags":[],
     "latin_names": "Macrolepiota Clelandii",
     "common_names": "Slender Parasol, Graceful Parason",
-    "description": "Macrolepiota clelandii, commonly known as the slender parasol or graceful parasol, is a species of mushroom-forming fungus in the family Agaricaceae. The species is found in Australia and New Zealand, where it fruits singly or in small groups on the ground in eucalypt woodlands, parks, and roadsides. It is a tall mushroom up to roughly 20 cm (8 in), with a broad cap covered with distinctive rings of dark brown scales. The whitish gills on the cap underside are closely spaced and free from attachment to the slender stipe, which has a loose ring on its upper half, and a bulbous base. The edibility of the mushroom is not known with certainty, but closely related parasol mushrooms are edible and some are very sought after.",
-    "lookalikes": "Macrolepiota Konradii, Chlorophyllum Molybdites / False Parasol",
+    "description": "Macrolepiota clelandii, commonly known as the slender parasol or graceful parasol, is a species of mushroom-forming fungus in the family Agaricaceae. \
+    The species is found in Australia and New Zealand, where it fruits singly or in small groups on the ground in eucalypt woodlands, parks, and roadsides. It is a tall mushroom \
+    up to roughly 20 cm (8 in), with a broad cap covered with distinctive rings of dark brown scales. The whitish gills on the cap underside are closely spaced and free from \
+    attachment to the slender stipe, which has a loose ring on its upper half, and a bulbous base. The edibility of the mushroom is not known with certainty, but closely related \
+    parasol mushrooms are edible and some are very sought after.",
+    "lookalikes": "M. procera is a larger with broad caps up to 12 in (30 cm) in diameter, and the stipe surface is covered with brownish zigzag bands or scaly girdles on a \
+    whitish background. The 'false parasol', Chlorophyllum molybdites, a toxic species that can be mistaken for M. konradii, also occurs in Australia (but not New Zealand). \
+    It can be distinguished by its green spore print and gills that turn light green in age. Some deadly poisonous Lepiota species have a similar pattern of scales on the cap, \
+    but their fruitbodies are smaller",
     "links": {
       "iNaturalist": "https://www.inaturalist.org/taxa/354649-Macrolepiota-clelandii",
       "wikipedia": "https://en.wikipedia.org/wiki/Macrolepiota_clelandii"
@@ -574,8 +607,13 @@ export default [
     "tags":["poisonous"],
     "latin_names": "Amanita Phalloides",
     "common_names": "Death Cap",
-    "description": "A. phalloides is one of the most poisonous of all known mushrooms. It is estimated that as little as half a mushroom contains enough toxin to kill an adult human. It has been involved in the majority of human deaths from mushroom poisonin. Young specimens first emerge from the ground resembling a white egg covered by a universal veil, which then breaks, leaving the volva as a remnant.",
-    "lookalikes": "None in NZ?",
+    "description": "A. phalloides is one of the most poisonous of all known mushrooms. It is estimated that as little as half a mushroom contains enough toxin to kill an \
+    adult human. It has been involved in the majority of human deaths from mushroom poisonin. Young specimens first emerge from the ground resembling a white egg covered by \
+    a universal veil, which then breaks, leaving the volva as a remnant.",
+    "lookalikes": "A. phalloides is similar to the edible paddy straw mushroom (Volvariella volvacea)[38] and A. princeps, commonly known as 'white Caesar'.[39] Some may mistake \
+    juvenile death caps for edible puffballs[40][41] or mature specimens for other edible Amanita species, such as A. lanei, so some authorities recommend avoiding the collecting \
+    of Amanita species for the table altogether.[42] The white form of A. phalloides may be mistaken for edible species of Agaricus, especially the young fruitbodies whose \
+    unexpanded caps conceal the telltale white gills; all mature species of Agaricus have dark-colored gills.",
     "links": {
       "iNaturalist": "https://www.inaturalist.org/taxa/52135-Amanita-phalloides",
       "wikipedia": "https://en.wikipedia.org/wiki/Amanita_phalloides"
@@ -617,8 +655,11 @@ export default [
     "tags":["edible"],
     "latin_names": "Armillaria novae-zelandiae",
     "common_names": "Austral Honey Mushroom, Harore",
-    "description": "This plant pathogen species is one of three Armillaria species that have been identified in New Zealand (the others are A. limonea and A. hinnulea).. Have a wide host range and can cause disease on a variety of tree species throughout New Zealand; particularly in plantations, home gardens, and parks. Armillaria novae-zelandiae occurs in indigenous forests as a decay fungus of dead trees, stumps, and logs. It causes butt rots in living trees as well",
-    "lookalikes": "None in NZ?",
+    "description": "This plant pathogen species is one of three Armillaria species that have been identified in New Zealand (the others are A. limonea and A. hinnulea). \
+    Have a wide host range and can cause disease on a variety of tree species throughout New Zealand; particularly in plantations, home gardens, and parks. Armillaria \
+    novae-zelandiae occurs in indigenous forests as a decay fungus of dead trees, stumps, and logs. It causes butt rots in living trees as well",
+    "lookalikes": "In both New Zealand and Australia, there are various mushrooms with similar appearances to Armillaria species. For example, some Galerina species and \
+    Cortinarius species may resemble Armillaria mushrooms. Some of these lookalikes can be toxic.",
     "links": {
       "iNaturalist": "https://www.inaturalist.org/taxa/55930-Armillaria",
       "wikipedia": "https://en.wikipedia.org/wiki/Armillaria"


### PR DESCRIPTION
Have added dynamic result card images & updated some lookalike fields.

The images are all public domain. All images are transformed to an aspect ratio of 3:4 and height: 1024, width:768 (slightly bigger than the old sample). As long as they're all the same size when pulled from Cloudinary we can make them responsive via CSS. 