### PR TITLE
Unit test fixes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
     'vue',
     'json'
   ],
+  setupFiles: ['<rootDir>/test-setup.js'],
   transform: {
       '^.+\\.ts$': 'ts-jest',
       '^.+\\.js$': 'babel-jest',
@@ -24,7 +25,7 @@ module.exports = {
     },
   collectCoverage: true,
   collectCoverageFrom: [
-    '<rootDir>/pages/index.vue'
+    '<rootDir>/pages/*.vue'
   ],
   testEnvironment: 'jsdom'
 }

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,0 +1,1 @@
+window.console.warn = () => { return '';}


### PR DESCRIPTION
Hide annoying console.warn messages when running Jest unit testing. Very small changes to jest configuration